### PR TITLE
Clean up shortwave data variable names

### DIFF
--- a/configuration/driver/icedrv_arrays_column.F90
+++ b/configuration/driver/icedrv_arrays_column.F90
@@ -120,37 +120,6 @@
          public :: &
          fswpenln       ! visible SW entering ice layers (W m-2)
 
-      ! aerosol optical properties   -> band  |
-      !                                       v aerosol
-      ! for combined dust category, use category 4 properties
-      real (kind=dbl_kind), dimension(icepack_nspint_3bd,icepack_max_aero), public :: &
-         kaer_3bd   , & ! aerosol mass extinction cross section (m2/kg)
-         waer_3bd   , & ! aerosol single scatter albedo (fraction)
-         gaer_3bd       ! aerosol asymmetry parameter (cos(theta))
-
-      real (kind=dbl_kind), dimension(icepack_nspint_3bd,icepack_nmodal1), public :: &
-         kaer_bc_3bd, & ! BC mass extinction cross section (m2/kg)
-         waer_bc_3bd, & ! BC single scatter albedo (fraction)
-         gaer_bc_3bd    ! BC aerosol asymmetry parameter (cos(theta))
-
-      real (kind=dbl_kind), &
-         dimension (icepack_nspint_3bd,icepack_nmodal1,icepack_nmodal2), public :: &
-         bcenh_3bd       ! BC absorption enhancement factor
-
-      real (kind=dbl_kind), dimension(icepack_nspint_5bd,icepack_max_aero), public :: &
-         kaer_5bd   , & ! aerosol mass extinction cross section (m2/kg)
-         waer_5bd   , & ! aerosol single scatter albedo (fraction)
-         gaer_5bd       ! aerosol asymmetry parameter (cos(theta))
-
-      real (kind=dbl_kind), dimension(icepack_nspint_5bd,icepack_nmodal1), public :: &
-         kaer_bc_5bd, & ! BC mass extinction cross section (m2/kg)
-         waer_bc_5bd, & ! BC single scatter albedo (fraction)
-         gaer_bc_5bd    ! BC aerosol asymmetry parameter (cos(theta))
-
-      real (kind=dbl_kind), &
-         dimension (icepack_nspint_5bd,icepack_nmodal1,icepack_nmodal2), public :: &
-         bcenh_5bd      ! BC absorption enhancement factor
-
       ! biogeochemistry components
 
       real (kind=dbl_kind), dimension (nblyr+2), public :: &

--- a/configuration/driver/icedrv_init_column.F90
+++ b/configuration/driver/icedrv_init_column.F90
@@ -99,11 +99,7 @@
       use icedrv_arrays_column, only: fswsfcn, ffracn, snowfracn
       use icedrv_arrays_column, only: fswthrun, fswthrun_vdr, fswthrun_vdf, fswthrun_idr, fswthrun_idf
       use icedrv_arrays_column, only: fswintn, albpndn, apeffn, trcrn_sw, dhsn
-      use icedrv_arrays_column, only: kaer_3bd, waer_3bd, gaer_3bd
-      use icedrv_arrays_column, only: kaer_bc_3bd, waer_bc_3bd, gaer_bc_3bd
-      use icedrv_arrays_column, only: kaer_5bd, waer_5bd, gaer_5bd
-      use icedrv_arrays_column, only: kaer_bc_5bd, waer_bc_5bd, gaer_bc_5bd
-      use icedrv_arrays_column, only: swgrid, igrid, bcenh_3bd, bcenh_5bd
+      use icedrv_arrays_column, only: swgrid, igrid
       use icedrv_calendar, only: istep1, dt, calendar_type
       use icedrv_calendar, only:    days_per_year, nextsw_cday, yday, sec
       use icedrv_system, only: icedrv_system_abort
@@ -278,10 +274,6 @@
                          calendar_type=calendar_type,          &
                          days_per_year=days_per_year,          &
                          nextsw_cday=nextsw_cday, yday=yday, sec=sec,      &
-                         kaer_3bd=kaer_3bd, kaer_bc_3bd=kaer_bc_3bd(:,:),  &
-                         waer_3bd=waer_3bd, waer_bc_3bd=waer_bc_3bd(:,:),  &
-                         gaer_3bd=gaer_3bd, gaer_bc_3bd=gaer_bc_3bd(:,:),  &
-                         bcenh_3bd=bcenh_3bd(:,:,:),                       &
                          modal_aero=modal_aero,                            &
                          swvdr=swvdr(i),         swvdf=swvdf(i),           &
                          swidr=swidr(i),         swidf=swidf(i),           &

--- a/configuration/driver/icedrv_step.F90
+++ b/configuration/driver/icedrv_step.F90
@@ -922,8 +922,7 @@
       use icedrv_arrays_column, only: fswthrun, fswthrun_vdr, fswthrun_vdf, fswthrun_idr, fswthrun_idf
       use icedrv_arrays_column, only: albicen, albsnon, albpndn
       use icedrv_arrays_column, only: alvdrn, alidrn, alvdfn, alidfn, apeffn, trcrn_sw, snowfracn
-      use icedrv_arrays_column, only: kaer_3bd, waer_3bd, gaer_3bd, kaer_bc_3bd, waer_bc_3bd
-      use icedrv_arrays_column, only: gaer_bc_3bd, bcenh_3bd, swgrid, igrid
+      use icedrv_arrays_column, only: swgrid, igrid
       use icedrv_calendar, only: calendar_type, days_per_year, nextsw_cday, yday, sec
       use icedrv_domain_size, only: ncat, n_aero, nilyr, nslyr, n_zaero, n_algae, nblyr, nx
       use icedrv_flux, only: swvdr, swvdf, swidr, swidf, coszen, fsnow
@@ -1043,10 +1042,7 @@
                          calendar_type=calendar_type,                   &
                          days_per_year=days_per_year, sec=sec,          &
                          nextsw_cday=nextsw_cday,   yday=yday,          &
-                         kaer_3bd=kaer_3bd,         kaer_bc_3bd=kaer_bc_3bd(:,:), &
-                         waer_3bd=waer_3bd,         waer_bc_3bd=waer_bc_3bd(:,:), &
-                         gaer_3bd=gaer_3bd,         gaer_bc_3bd=gaer_bc_3bd(:,:), &
-                         bcenh_3bd=bcenh_3bd(:,:,:),        modal_aero=modal_aero,    &
+                         modal_aero=modal_aero,                         &
                          swvdr=swvdr(i),            swvdf=swvdf(i),           &
                          swidr=swidr(i),            swidf=swidf(i),           &
                          coszen=coszen(i),          fsnow=fsnow(i),           &


### PR DESCRIPTION

Clean up icepack_shortwave_data variable names in icepack_shortwave.
Migrate to "use", get rid of shortwave data that is passed.
Get rid of redundant data defined in icepack_shortwave.
Get rid of a few unused variables in icepack_shortwave.