### PR TITLE
Clean up icepack_shortwave

### DIFF
--- a/configuration/driver/icedrv_calendar.F90
+++ b/configuration/driver/icedrv_calendar.F90
@@ -78,7 +78,6 @@
          yday           , & ! day of the year
          tday           , & ! absolute day number
          dayyr          , & ! number of days per year
-         nextsw_cday    , & ! julian day of next shortwave calculation
          basis_seconds  , & ! Seconds since calendar zero
          secday             ! seconds per day
 

--- a/configuration/driver/icedrv_init_column.F90
+++ b/configuration/driver/icedrv_init_column.F90
@@ -247,10 +247,8 @@
             enddo
 
             if (tmask(i)) then
-            call icepack_step_radiation (              &
-                         dt=dt,           ncat=ncat,           &
-                         nblyr=nblyr,                          &
-                         nilyr=nilyr,     nslyr=nslyr,         &
+            call icepack_step_radiation (                      &
+                         dt=dt,                                &
                          swgrid=swgrid(:),                     &
                          igrid=igrid(:),                       &
                          fbri=fbri(:),                         &

--- a/configuration/driver/icedrv_init_column.F90
+++ b/configuration/driver/icedrv_init_column.F90
@@ -100,8 +100,7 @@
       use icedrv_arrays_column, only: fswthrun, fswthrun_vdr, fswthrun_vdf, fswthrun_idr, fswthrun_idf
       use icedrv_arrays_column, only: fswintn, albpndn, apeffn, trcrn_sw, dhsn
       use icedrv_arrays_column, only: swgrid, igrid
-      use icedrv_calendar, only: istep1, dt, calendar_type
-      use icedrv_calendar, only:    days_per_year, nextsw_cday, yday, sec
+      use icedrv_calendar, only: istep1, dt, yday, sec
       use icedrv_system, only: icedrv_system_abort
       use icedrv_forcing, only: snw_ssp_table
       use icedrv_flux, only: alvdf, alidf, alvdr, alidr
@@ -123,7 +122,6 @@
          l_print_point, & ! flag to print designated grid point diagnostics
          use_snicar,    & ! use 5-band SNICAR radiation scheme for snow
          dEdd_algae,    & ! BGC - radiation interactions
-         modal_aero,    & ! modal aerosol optical properties
          snwgrain         ! use variable snow grain size
 
       character (len=char_len) :: &
@@ -153,7 +151,6 @@
          call icepack_query_parameters(puny_out=puny)
          call icepack_query_parameters(shortwave_out=shortwave)
          call icepack_query_parameters(dEdd_algae_out=dEdd_algae)
-         call icepack_query_parameters(modal_aero_out=modal_aero)
          call icepack_query_parameters(snwgrain_out=snwgrain)
          call icepack_query_tracer_sizes(ntrcr_out=ntrcr, &
               nbtrcr_sw_out=nbtrcr_sw)
@@ -254,7 +251,6 @@
                          dt=dt,           ncat=ncat,           &
                          nblyr=nblyr,                          &
                          nilyr=nilyr,     nslyr=nslyr,         &
-                         dEdd_algae=dEdd_algae,                &
                          swgrid=swgrid(:),                     &
                          igrid=igrid(:),                       &
                          fbri=fbri(:),                         &
@@ -271,10 +267,7 @@
                          zaeron=trcrn(i,nt_zaero(1):nt_zaero(1)+n_zaero*(nblyr+3)-1,:), &
                          trcrn_bgcsw=ztrcr_sw,                 &
                          TLAT=TLAT(i), TLON=TLON(i),           &
-                         calendar_type=calendar_type,          &
-                         days_per_year=days_per_year,          &
-                         nextsw_cday=nextsw_cday, yday=yday, sec=sec,      &
-                         modal_aero=modal_aero,                            &
+                         yday=yday, sec=sec,                   &
                          swvdr=swvdr(i),         swvdf=swvdf(i),           &
                          swidr=swidr(i),         swidf=swidf(i),           &
                          coszen=coszen(i),       fsnow=fsnow(i),           &

--- a/configuration/driver/icedrv_step.F90
+++ b/configuration/driver/icedrv_step.F90
@@ -923,7 +923,7 @@
       use icedrv_arrays_column, only: albicen, albsnon, albpndn
       use icedrv_arrays_column, only: alvdrn, alidrn, alvdfn, alidfn, apeffn, trcrn_sw, snowfracn
       use icedrv_arrays_column, only: swgrid, igrid
-      use icedrv_calendar, only: calendar_type, days_per_year, nextsw_cday, yday, sec
+      use icedrv_calendar, only: yday, sec
       use icedrv_domain_size, only: ncat, n_aero, nilyr, nslyr, n_zaero, n_algae, nblyr, nx
       use icedrv_flux, only: swvdr, swvdf, swidr, swidf, coszen, fsnow
       use icedrv_init, only: TLAT, TLON, tmask
@@ -949,7 +949,7 @@
          nlt_zaero_sw, nt_zaero, nt_bgc_N
 
       logical (kind=log_kind) :: &
-         tr_bgc_N, tr_zaero, tr_brine, dEdd_algae, modal_aero, snwgrain
+         tr_bgc_N, tr_zaero, tr_brine, dEdd_algae, snwgrain
 
       real (kind=dbl_kind), dimension(ncat) :: &
          fbri               ! brine height to ice thickness
@@ -997,8 +997,7 @@
       if (icepack_warnings_aborted()) call icedrv_system_abort(string=subname, &
           file=__FILE__,line= __LINE__)
 
-      call icepack_query_parameters(dEdd_algae_out=dEdd_algae, modal_aero_out=modal_aero, &
-           snwgrain_out=snwgrain)
+      call icepack_query_parameters(dEdd_algae_out=dEdd_algae, snwgrain_out=snwgrain)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call icedrv_system_abort(string=subname, &
           file=__FILE__,line= __LINE__)
@@ -1024,7 +1023,7 @@
 
             call icepack_step_radiation(dt=dt,      ncat=ncat,          &
                          nblyr=nblyr,               nilyr=nilyr,        &
-                         nslyr=nslyr,               dEdd_algae=dEdd_algae,        &
+                         nslyr=nslyr,                                   &
                          swgrid=swgrid(:),          igrid=igrid(:),     &
                          fbri=fbri(:),                                  &
                          aicen=aicen(i,:),          vicen=vicen(i,:),   &
@@ -1039,10 +1038,7 @@
                          zaeron=trcrn(i,nt_zaero(1):nt_zaero(1)+n_zaero*(nblyr+3)-1,:), &
                          trcrn_bgcsw=ztrcr_sw,                          &
                          TLAT=TLAT(i),              TLON=TLON(i),       &
-                         calendar_type=calendar_type,                   &
-                         days_per_year=days_per_year, sec=sec,          &
-                         nextsw_cday=nextsw_cday,   yday=yday,          &
-                         modal_aero=modal_aero,                         &
+                         sec=sec,                   yday=yday,          &
                          swvdr=swvdr(i),            swvdf=swvdf(i),           &
                          swidr=swidr(i),            swidf=swidf(i),           &
                          coszen=coszen(i),          fsnow=fsnow(i),           &

--- a/configuration/driver/icedrv_step.F90
+++ b/configuration/driver/icedrv_step.F90
@@ -67,7 +67,7 @@
             alidr_init(i) = alidr_ai(i)
             alidf_init(i) = alidf_ai(i)
 
-            call icepack_prep_radiation(ncat=ncat, nilyr=nilyr, nslyr=nslyr, &
+            call icepack_prep_radiation( &
                          aice=aice(i),   aicen=aicen(i,:), &
                          swvdr=swvdr(i), swvdf=swvdf(i),   &
                          swidr=swidr(i), swidf=swidf(i),   &
@@ -1021,9 +1021,7 @@
 
          if (tmask(i)) then
 
-            call icepack_step_radiation(dt=dt,      ncat=ncat,          &
-                         nblyr=nblyr,               nilyr=nilyr,        &
-                         nslyr=nslyr,                                   &
+            call icepack_step_radiation(dt=dt,                          &
                          swgrid=swgrid(:),          igrid=igrid(:),     &
                          fbri=fbri(:),                                  &
                          aicen=aicen(i,:),          vicen=vicen(i,:),   &


### PR DESCRIPTION
- Remove modal_aero, dEdd_algae, and heat_capacity from icepack_shortwave arguments, use directly from icepack_parameters
- Modify fswthrun_ optional argument implementation
- Modify rsnow optional argument implementation
- Change days_per_year, nextsw_cday, and calendar_type to optional arguments in icepack_step_radiation and down the calling tree
- Fix some indentation
