### PR TITLE
Update implementation of g(k), w0(k) in icepack_shortwave

### DIFF
--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -227,8 +227,6 @@
          sw_dtemp     = 0.02_dbl_kind       ! temperature difference from melting
 
       ! Parameters for dEdd_snicar_ad
-      logical (kind=log_kind), public :: &
-         use_snicar = .false.     ! .true. use 5-band SNICAR-AD approach
       character (len=char_len), public :: &
          snw_ssp_table = 'test'   ! lookup table: 'snicar' or 'test'
 
@@ -462,7 +460,7 @@
          update_ocn_f_in, ustar_min_in, a_rapid_mode_in, &
          Rac_rapid_mode_in, aspect_rapid_mode_in, &
          dSdt_slow_mode_in, phi_c_slow_mode_in, &
-         phi_i_mushy_in, shortwave_in, use_snicar_in, albedo_type_in, albsnowi_in, &
+         phi_i_mushy_in, shortwave_in, albedo_type_in, albsnowi_in, &
          albicev_in, albicei_in, albsnowv_in, &
          ahmax_in, R_ice_in, R_pnd_in, R_snw_in, dT_mlt_in, rsnw_mlt_in, &
          kalg_in, kstrength_in, krdg_partic_in, krdg_redist_in, mu_rdg_in, &
@@ -635,7 +633,6 @@
          kalg_in         ! algae absorption coefficient for 0.5 m thick layer
 
       logical (kind=log_kind), intent(in), optional :: &
-         use_snicar_in,& ! snicar adjustments to dEdd radiation for snow
          sw_redist_in    ! redistribute shortwave
 
       real (kind=dbl_kind), intent(in), optional :: &
@@ -939,7 +936,6 @@
       if (present(phi_c_slow_mode_in)   ) phi_c_slow_mode  = phi_c_slow_mode_in
       if (present(phi_i_mushy_in)       ) phi_i_mushy      = phi_i_mushy_in
       if (present(shortwave_in)         ) shortwave        = shortwave_in
-      if (present(use_snicar_in)        ) use_snicar       = use_snicar_in
       if (present(albedo_type_in)       ) albedo_type      = albedo_type_in
       if (present(albicev_in)           ) albicev          = albicev_in
       if (present(albicei_in)           ) albicei          = albicei_in
@@ -1178,7 +1174,7 @@
          Lfresh_out, cprho_out, Cp_out, ustar_min_out, a_rapid_mode_out, &
          ktherm_out, conduct_out, fbot_xfer_type_out, calc_Tsfc_out, dts_b_out, &
          Rac_rapid_mode_out, aspect_rapid_mode_out, dSdt_slow_mode_out, &
-         phi_c_slow_mode_out, phi_i_mushy_out, shortwave_out, use_snicar_out, &
+         phi_c_slow_mode_out, phi_i_mushy_out, shortwave_out, &
          albedo_type_out, albicev_out, albicei_out, albsnowv_out, &
          albsnowi_out, ahmax_out, R_ice_out, R_pnd_out, R_snw_out, dT_mlt_out, &
          rsnw_mlt_out, dEdd_algae_out, &
@@ -1361,7 +1357,6 @@
          kalg_out         ! algae absorption coefficient for 0.5 m thick layer
 
       logical (kind=log_kind), intent(out), optional :: &
-         use_snicar_out,& ! snicar adjustments to dEdd radiation for snow
          sw_redist_out    ! redistribute shortwave
 
       real (kind=dbl_kind), intent(out), optional :: &
@@ -1697,7 +1692,6 @@
       if (present(phi_c_slow_mode_out)   ) phi_c_slow_mode_out = phi_c_slow_mode
       if (present(phi_i_mushy_out)       ) phi_i_mushy_out  = phi_i_mushy
       if (present(shortwave_out)         ) shortwave_out    = shortwave
-      if (present(use_snicar_out)        ) use_snicar_out   = use_snicar
       if (present(albedo_type_out)       ) albedo_type_out  = albedo_type
       if (present(albicev_out)           ) albicev_out      = albicev
       if (present(albicei_out)           ) albicei_out      = albicei
@@ -1908,7 +1902,6 @@
         write(iounit,*) "  phi_c_slow_mode   = ", phi_c_slow_mode
         write(iounit,*) "  phi_i_mushy       = ", phi_i_mushy
         write(iounit,*) "  shortwave     = ", shortwave
-        write(iounit,*) "  use_snicar    = ", use_snicar
         write(iounit,*) "  albedo_type   = ", albedo_type
         write(iounit,*) "  albicev       = ", albicev
         write(iounit,*) "  albicei       = ", albicei

--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -214,7 +214,7 @@
          awtidf = 0.36218_dbl_kind   ! near IR, diffuse
 
       character (len=char_len), public :: &
-         shortwave   = 'dEdd', & ! shortwave method, 'ccsm3' or 'dEdd' or 'dEdd_snicar'
+         shortwave   = 'dEdd', & ! shortwave method, 'ccsm3' or 'dEdd' or 'dEdd_snicar_ad'
          albedo_type = 'ccsm3'   ! albedo parameterization, 'ccsm3' or 'constant'
                                  ! shortwave='dEdd' overrides this parameter
 
@@ -226,7 +226,7 @@
          sw_frac      = 0.9_dbl_kind    , & ! Fraction of internal shortwave moved to surface
          sw_dtemp     = 0.02_dbl_kind       ! temperature difference from melting
 
-      ! Parameters for dEdd_snicar
+      ! Parameters for dEdd_snicar_ad
       logical (kind=log_kind), public :: &
          use_snicar = .false.     ! .true. use 5-band SNICAR-AD approach
       character (len=char_len), public :: &
@@ -612,7 +612,7 @@
          awtidf_in        ! near IR, diffuse
 
       character (len=*), intent(in), optional :: &
-         shortwave_in, & ! shortwave method, 'ccsm3' or 'dEdd' or 'dEdd_snicar'
+         shortwave_in, & ! shortwave method, 'ccsm3' or 'dEdd' or 'dEdd_snicar_ad'
          albedo_type_in  ! albedo parameterization, 'ccsm3' or 'constant'
                          ! shortwave='dEdd' overrides this parameter
 
@@ -1338,7 +1338,7 @@
          awtidf_out        ! near IR, diffuse
 
       character (len=*), intent(out), optional :: &
-         shortwave_out, & ! shortwave method, 'ccsm3' or 'dEdd' or 'dEdd_snicar'
+         shortwave_out, & ! shortwave method, 'ccsm3' or 'dEdd' or 'dEdd_snicar_ad'
          albedo_type_out  ! albedo parameterization, 'ccsm3' or 'constant'
                              ! shortwave='dEdd' overrides this parameter
 

--- a/columnphysics/icepack_shortwave.F90
+++ b/columnphysics/icepack_shortwave.F90
@@ -54,7 +54,7 @@
       use icepack_parameters, only: z_tracers, skl_bgc, calc_tsfc, shortwave, kalg
       use icepack_parameters, only: R_ice, R_pnd, R_snw, dT_mlt, rsnw_mlt, hs0, hs1, hp1
       use icepack_parameters, only: pndaspect, albedo_type, albicev, albicei, albsnowv, albsnowi, ahmax
-      use icepack_parameters, only: snw_ssp_table, use_snicar, modal_aero
+      use icepack_parameters, only: snw_ssp_table, modal_aero
       use icepack_parameters, only: dEdd_algae
 
       use icepack_tracers,    only: ncat, nilyr, nslyr, nblyr
@@ -173,7 +173,7 @@
          if (icepack_warnings_aborted(subname)) return
       endif
 
-      if (use_snicar) then
+      if (trim(shortwave) == 'dEdd_snicar_ad') then
          call icepack_shortwave_init_dEdd5band()
          if (icepack_warnings_aborted(subname)) return
 
@@ -1507,7 +1507,7 @@
                ! calculate snow covered sea ice
 
                srftyp = 1
-               if (use_snicar) then
+               if (trim(shortwave) == 'dEdd_snicar_ad') then
                 call compute_dEdd_5bd(klev, klevp,                        &
                         zbio,                                             &
                         fnidr,     coszen,                                &

--- a/columnphysics/icepack_shortwave.F90
+++ b/columnphysics/icepack_shortwave.F90
@@ -2362,12 +2362,10 @@
             ! aerosol in snow
             if (tr_zaero .and. dEdd_algae) then
                do k = 0,nslyr
-                  gzaer(ns,k) = gzaer(ns,k)/(wzaer(ns,k)+puny)
-                  wzaer(ns,k) = wzaer(ns,k)/(tzaer(ns,k)+puny)
-                  g  (k) = (g (k)*w0(k)*tau(k) + gzaer(ns,k)*wzaer(ns,k)*tzaer(ns,k)) &
-                         /       (w0(k)*tau(k) +             wzaer(ns,k)*tzaer(ns,k))
-                  w0 (k) = (      w0(k)*tau(k) +             wzaer(ns,k)*tzaer(ns,k)) &
-                         /       (      tau(k) +                         tzaer(ns,k))
+                  g(k)   = (g(k)*w0(k)*tau(k) + gzaer(ns,k)) / &
+                                (w0(k)*tau(k) + wzaer(ns,k))
+                  w0(k)  =      (w0(k)*tau(k) + wzaer(ns,k)) / &
+                                      (tau(k) + tzaer(ns,k))
                   tau(k) = tau(k) + tzaer(ns,k)
                enddo
             elseif (tr_aero) then
@@ -2412,6 +2410,8 @@
                enddo       ! na
                gaer = gaer/(waer+puny)
                waer = waer/(taer+puny)
+
+! tcraig, why does the above section exist if taer=waer=gaer=0 below
 
                do k=1,nslyr
                   taer = c0
@@ -2462,12 +2462,10 @@
                             waer_3bd(ns,(1+(na-1)/4))*gaer_3bd(ns,(1+(na-1)/4))
                   endif       ! modal_aero
                   enddo       ! na
-                  gaer = gaer/(waer+puny)
-                  waer = waer/(taer+puny)
-                  g(k)   = (g(k)*w0(k)*tau(k) + gaer*waer*taer) / &
-                           (w0(k)*tau(k) + waer*taer)
-                  w0(k)  = (w0(k)*tau(k) + waer*taer) / &
-                           (tau(k) + taer)
+                  g(k)   = (g(k)*w0(k)*tau(k) + gaer) / &
+                                (w0(k)*tau(k) + waer)
+                  w0(k)  =      (w0(k)*tau(k) + waer) / &
+                                      (tau(k) + taer)
                   tau(k) = tau(k) + taer
                enddo       ! k
             endif     ! tr_aero
@@ -2523,12 +2521,10 @@
             ! aerosol in sea ice
             if (tr_zaero .and. dEdd_algae) then
                do k = kii, klev
-                  gzaer(ns,k) = gzaer(ns,k)/(wzaer(ns,k)+puny)
-                  wzaer(ns,k) = wzaer(ns,k)/(tzaer(ns,k)+puny)
-                  g(k)   = (g(k)*w0(k)*tau(k) + gzaer(ns,k)*wzaer(ns,k)*tzaer(ns,k)) &
-                         /      (w0(k)*tau(k) +             wzaer(ns,k)*tzaer(ns,k))
-                  w0(k)  = (w0(k)*tau(k) + wzaer(ns,k)*tzaer(ns,k)) &
-                         /       (tau(k) +             tzaer(ns,k))
+                  g(k)   = (g(k)*w0(k)*tau(k) + gzaer(ns,k)) / &
+                                (w0(k)*tau(k) + wzaer(ns,k))
+                  w0(k)  =      (w0(k)*tau(k) + wzaer(ns,k)) / &
+                                      (tau(k) + tzaer(ns,k))
                   tau(k) = tau(k) + tzaer(ns,k)
                enddo
             elseif (tr_aero) then
@@ -2579,12 +2575,10 @@
                 endif     ! modal_aero
                enddo      ! na
 
-               gaer = gaer/(waer+puny)
-               waer = waer/(taer+puny)
-               g(k)   = (g(k)*w0(k)*tau(k) + gaer*waer*taer) / &
-                    (w0(k)*tau(k) + waer*taer)
-               w0(k)  = (w0(k)*tau(k) + waer*taer) / &
-                    (tau(k) + taer)
+               g(k)   = (g(k)*w0(k)*tau(k) + gaer) / &
+                             (w0(k)*tau(k) + waer)
+               w0(k)  =      (w0(k)*tau(k) + waer) / &
+                                   (tau(k) + taer)
                tau(k) = tau(k) + taer
                do k = kii+1, klev
                   taer = c0
@@ -2632,12 +2626,10 @@
                           waer_3bd(ns,(1+(na-1)/4))*gaer_3bd(ns,(1+(na-1)/4))
                   endif       ! modal_aero
                   enddo       ! na
-                  gaer = gaer/(waer+puny)
-                  waer = waer/(taer+puny)
-                  g(k)   = (g(k)*w0(k)*tau(k) + gaer*waer*taer) / &
-                           (w0(k)*tau(k) + waer*taer)
-                  w0(k)  = (w0(k)*tau(k) + waer*taer) / &
-                           (tau(k) + taer)
+                  g(k)   = (g(k)*w0(k)*tau(k) + gaer) / &
+                                (w0(k)*tau(k) + waer)
+                  w0(k)  =      (w0(k)*tau(k) + waer) / &
+                                      (tau(k) + taer)
                   tau(k) = tau(k) + taer
                enddo ! k
             endif ! tr_aero
@@ -4969,9 +4961,9 @@
           if (tr_zaero .and. dEdd_algae) then
             do k = 0,nslyr
                g(k)   = (g(k)*w0(k)*tau(k) + gzaer_5bd(ns,k)) / &
-                               (w0(k)*tau(k) + wzaer_5bd(ns,k))
-               w0(k)  = (w0(k)*tau(k) + wzaer_5bd(ns,k)) / &
-                                (tau(k) + tzaer_5bd(ns,k))
+                             (w0(k)*tau(k) + wzaer_5bd(ns,k))
+               w0(k)  =      (w0(k)*tau(k) + wzaer_5bd(ns,k)) / &
+                                   (tau(k) + tzaer_5bd(ns,k))
                tau(k) = tau(k) + tzaer_5bd(ns,k)
             enddo
           elseif (tr_aero) then
@@ -5030,6 +5022,8 @@
                gaer = gaer/(waer+puny)
                waer = waer/(taer+puny)
 
+! tcraig, again why does the above exist if taer=waer=gaer=0 below
+
                do k=1,nslyr
                   taer = c0
                   waer = c0
@@ -5083,12 +5077,10 @@
                   endif       ! modal_aero
 !mgf--
                   enddo       ! na
-                  gaer = gaer/(waer+puny)
-                  waer = waer/(taer+puny)
-                  g(k)   = (g(k)*w0(k)*tau(k) + gaer*waer*taer) / &
-                           (w0(k)*tau(k) + waer*taer)
-                  w0(k)  = (w0(k)*tau(k) + waer*taer) / &
-                           (tau(k) + taer)
+                  g(k)   = (g(k)*w0(k)*tau(k) + gaer) / &
+                                (w0(k)*tau(k) + waer)
+                  w0(k)  =      (w0(k)*tau(k) + waer) / &
+                                      (tau(k) + taer)
                   tau(k) = tau(k) + taer
                enddo       ! k
             endif     ! tr_aero
@@ -5134,9 +5126,9 @@
                if (tr_zaero .and. dEdd_algae) then
                   do k = kii, klev
                      g(k)   = (g(k)*w0(k)*tau(k) + gzaer_5bd(ns,k)) / &
-                                     (w0(k)*tau(k) + wzaer_5bd(ns,k))
-                     w0(k)  = (w0(k)*tau(k) + wzaer_5bd(ns,k)) / &
-                                      (tau(k) + tzaer_5bd(ns,k))
+                                   (w0(k)*tau(k) + wzaer_5bd(ns,k))
+                     w0(k)  =      (w0(k)*tau(k) + wzaer_5bd(ns,k)) / &
+                                         (tau(k) + tzaer_5bd(ns,k))
                      tau(k) = tau(k) + tzaer_5bd(ns,k)
                   enddo
                elseif (tr_aero) then
@@ -5192,12 +5184,10 @@
    !mgf--
                   enddo      ! na
 
-                  gaer = gaer/(waer+puny)
-                  waer = waer/(taer+puny)
-                  g(k)   = (g(k)*w0(k)*tau(k) + gaer*waer*taer) / &
-                       (w0(k)*tau(k) + waer*taer)
-                  w0(k)  = (w0(k)*tau(k) + waer*taer) / &
-                       (tau(k) + taer)
+                  g(k)   = (g(k)*w0(k)*tau(k) + gaer) / &
+                                (w0(k)*tau(k) + waer)
+                  w0(k)  =      (w0(k)*tau(k) + waer) / &
+                                      (tau(k) + taer)
                   tau(k) = tau(k) + taer
                   do k = kii+1, klev
                      taer = c0
@@ -5252,12 +5242,10 @@
                      endif       ! modal_aero
    !mgf--
                      enddo       ! na
-                     gaer = gaer/(waer+puny)
-                     waer = waer/(taer+puny)
-                     g(k)   = (g(k)*w0(k)*tau(k) + gaer*waer*taer) / &
-                              (w0(k)*tau(k) + waer*taer)
-                     w0(k)  = (w0(k)*tau(k) + waer*taer) / &
-                              (tau(k) + taer)
+                     g(k)   = (g(k)*w0(k)*tau(k) + gaer) / &
+                                   (w0(k)*tau(k) + waer)
+                     w0(k)  =      (w0(k)*tau(k) + waer) / &
+                                         (tau(k) + taer)
                      tau(k) = tau(k) + taer
                   enddo ! k
                endif ! tr_aero

--- a/columnphysics/icepack_shortwave_data.F90
+++ b/columnphysics/icepack_shortwave_data.F90
@@ -5,7 +5,7 @@
       use icepack_warnings, only: warnstr, icepack_warnings_add
       use icepack_warnings, only: icepack_warnings_setabort, icepack_warnings_aborted
       use icepack_parameters, only: c0
-      use icepack_parameters, only: use_snicar, snw_ssp_table
+      use icepack_parameters, only: snw_ssp_table
       use icepack_tracers, only: nmodal1, nmodal2, max_aero
 
       implicit none

--- a/columnphysics/icepack_shortwave_data.F90
+++ b/columnphysics/icepack_shortwave_data.F90
@@ -5,7 +5,6 @@
       use icepack_warnings, only: warnstr, icepack_warnings_add
       use icepack_warnings, only: icepack_warnings_setabort, icepack_warnings_aborted
       use icepack_parameters, only: c0
-      use icepack_parameters, only: snw_ssp_table
       use icepack_tracers, only: nmodal1, nmodal2, max_aero
 
       implicit none

--- a/configuration/driver/icedrv_init.F90
+++ b/configuration/driver/icedrv_init.F90
@@ -715,7 +715,7 @@
          write(nu_diag,1000) ' ahmax                     = ', ahmax
          endif
 
-         if (trim(shortwave) == 'dEdd_snicar') then
+         if (trim(shortwave) == 'dEdd_snicar_ad') then
          write(nu_diag,1030) ' snw_ssp_table             = ', trim(snw_ssp_table)
          endif
 

--- a/configuration/driver/icedrv_init_column.F90
+++ b/configuration/driver/icedrv_init_column.F90
@@ -221,7 +221,7 @@
             if (icepack_warnings_aborted()) &
                call icedrv_system_abort(i, istep1, subname, __FILE__, __LINE__)
 
-            if (trim(shortwave) == 'dEdd_snicar') then
+            if (trim(shortwave) == 'dEdd_snicar_ad') then
                use_snicar = .true. ! 5-band SNICAR scheme for snow cover
                call icepack_init_parameters(use_snicar_in=use_snicar, snw_ssp_table_in=snw_ssp_table)
                call icepack_warnings_flush(nu_diag)

--- a/configuration/driver/icedrv_init_column.F90
+++ b/configuration/driver/icedrv_init_column.F90
@@ -120,7 +120,6 @@
 
       logical (kind=log_kind) :: &
          l_print_point, & ! flag to print designated grid point diagnostics
-         use_snicar,    & ! use 5-band SNICAR radiation scheme for snow
          dEdd_algae,    & ! BGC - radiation interactions
          snwgrain         ! use variable snow grain size
 
@@ -222,8 +221,7 @@
                call icedrv_system_abort(i, istep1, subname, __FILE__, __LINE__)
 
             if (trim(shortwave) == 'dEdd_snicar_ad') then
-               use_snicar = .true. ! 5-band SNICAR scheme for snow cover
-               call icepack_init_parameters(use_snicar_in=use_snicar, snw_ssp_table_in=snw_ssp_table)
+               call icepack_init_parameters(snw_ssp_table_in=snw_ssp_table)
                call icepack_warnings_flush(nu_diag)
                if (icepack_warnings_aborted()) call icedrv_system_abort(string=subname, &
                    file=__FILE__,line= __LINE__)

--- a/configuration/scripts/options/set_nml.snicar
+++ b/configuration/scripts/options/set_nml.snicar
@@ -1,2 +1,2 @@
-  shortwave          = 'dEdd_snicar'
+  shortwave          = 'dEdd_snicar_ad'
   snw_ssp_table      = 'snicar'

--- a/configuration/scripts/options/set_nml.snicartest
+++ b/configuration/scripts/options/set_nml.snicartest
@@ -1,2 +1,2 @@
-  shortwave       = 'dEdd_snicar'
+  shortwave       = 'dEdd_snicar_ad'
   snw_ssp_table   = 'test'


### PR DESCRIPTION
- consistent with https://github.com/MPAS-Dev/MPAS-Model/commit/b76b6830
- Rename the dEdd_snicar option to dEdd_snicar_ad

This is bit-for-bit for full suite of Icepack testing on cheyenne.  We are not testing modal aerosols in standalone Icepack (or CICE) because it hasn't been working.